### PR TITLE
Require third-party modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "worker"
   ],
   "author": "Andy Earnshaw",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "rollup": "^0.43.0"
+  }
 }


### PR DESCRIPTION
Call `rollup.rollup()` from the plugin's load function, allowing imported scripts to in turn import their own scripts. The configuration used in the original bundle is carried through to the worker bundle, ensuring babel/uglify/etc. still get run there.

Thanks! :)